### PR TITLE
Refactor logging levels from warning to debug for improved log clarity

### DIFF
--- a/custom_components/laifen_ble/__init__.py
+++ b/custom_components/laifen_ble/__init__.py
@@ -273,7 +273,7 @@ async def _async_device_recovery(hass: HomeAssistant, entry: ConfigEntry, servic
         if await laifen.connect():
             await laifen.start_notifications()
             await laifen.coordinator.async_request_refresh()
-            _LOGGER.info(f"Successfully reconnected to {device_address}.")
+            _LOGGER.debug(f"Successfully reconnected to {device_address}.")
         else:
             _LOGGER.debug(f"Failed to reconnect {device_address}. Retrying on next callback event.")
     else:

--- a/custom_components/laifen_ble/__init__.py
+++ b/custom_components/laifen_ble/__init__.py
@@ -95,7 +95,7 @@ class LaifenCoordinator(DataUpdateCoordinator):
 
                     
         except (BleakError, asyncio.TimeoutError) as e:
-            _LOGGER.error(f"BLE error during update: {e}. Will retry before marking asleep.")
+            _LOGGER.debug(f"BLE error during update: {e}. Will retry before marking asleep.")
             # Don't immediately mark as asleep - will happen automatically if retries fail
             cached = await self._async_restore_data()
             self.async_set_updated_data(cached or {})

--- a/custom_components/laifen_ble/config_flow.py
+++ b/custom_components/laifen_ble/config_flow.py
@@ -27,7 +27,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Discover available Bluetooth devices
         devices = bluetooth.async_discovered_service_info(self.hass)
 
-        _LOGGER.warning(f"Discovered devices: {[device.name for device in devices]}")  # Log all discovered devices
+        _LOGGER.debug(f"Discovered devices: {[device.name for device in devices]}")  # Log all discovered devices
         found_devices = {device.name: device.address for device in devices if device.name.startswith("LFTB")}
         
         if not found_devices:

--- a/custom_components/laifen_ble/config_flow.py
+++ b/custom_components/laifen_ble/config_flow.py
@@ -31,7 +31,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         found_devices = {device.name: device.address for device in devices if device.name.startswith("LFTB")}
         
         if not found_devices:
-            _LOGGER.error("No Laifen devices found via Bluetooth scan.")
+            _LOGGER.debug("No Laifen devices found via Bluetooth scan.")
             return self.async_abort(reason="no_matching_device_found")
 
         # If multiple devices, prompt user to select

--- a/custom_components/laifen_ble/laifen/laifen.py
+++ b/custom_components/laifen_ble/laifen/laifen.py
@@ -88,7 +88,7 @@ class Laifen:
         async with self.lock:
             if self.client and self.client.is_connected:
                 try:
-                    # _LOGGER.info(f"Sending command to {self.ble_device.address}: {command.hex()}")
+                    # _LOGGER.debug(f"Sending command to {self.ble_device.address}: {command.hex()}")
                     await self.client.write_gatt_char(CHARACTERISTIC_UUID, command)
                     return True
                 except BleakError as e:
@@ -97,12 +97,12 @@ class Laifen:
 
     async def turn_on(self):
         """Turn on the Laifen toothbrush."""
-        _LOGGER.info(f"Turning on {self.ble_device.address}...")
+        _LOGGER.debug(f"Turning on {self.ble_device.address}...")
         return await self.send_command(bytes.fromhex("AA0F010101A4"))
 
     async def turn_off(self):
         """Turn off the Laifen toothbrush."""
-        _LOGGER.info(f"Turning off {self.ble_device.address}...")
+        _LOGGER.debug(f"Turning off {self.ble_device.address}...")
         return await self.send_command(bytes.fromhex("AA0F010100A5"))
 
     async def gatherdata(self):
@@ -167,7 +167,7 @@ class Laifen:
                 # _LOGGER.warning(f"Failed to start notifications (attempt {attempt+1}/5): {e}")
                 await asyncio.sleep(1)
 
-        _LOGGER.error(f"Could not start notifications for {self.ble_device.address} after multiple retries.")
+        _LOGGER.debug(f"Could not start notifications for {self.ble_device.address} after multiple retries.")
 
         # Fallback — treat device as asleep and defer to recovery next time
         if self.coordinator:
@@ -190,7 +190,7 @@ class Laifen:
 
     def notification_handler(self, sender, data):
         if not self.coordinator:
-            _LOGGER.error("⚠️ self.coordinator is not assigned — cannot update HA entities!")
+            _LOGGER.debug("⚠️ self.coordinator is not assigned — cannot update HA entities!")
             return
         # else:
             # _LOGGER.debug(f"✅ Coordinator is assigned: {self.coordinator}")
@@ -251,7 +251,7 @@ class Laifen:
             }
 
         except Exception as e:
-            _LOGGER.error(f"Unexpected error while parsing data: {e}")
+            _LOGGER.debug(f"Unexpected error while parsing data: {e}")
             return {key: 0 if key != "raw_data" else data_str for key in ["raw_data", "status", "mode", "battery_level", "brushing_time", "vibration_strength", "oscillation_range", "oscillation_speed"]}
         
         # return parsed_result  # ✅ Returns the full dictionary
@@ -304,7 +304,7 @@ class Laifen:
                                 break
 
                         await asyncio.sleep(initial_delay)
-                        _LOGGER.info(f"Reconnect attempt {attempt + 1}/{max_attempts} for {self.address}")
+                        _LOGGER.debug(f"Reconnect attempt {attempt + 1}/{max_attempts} for {self.address}")
 
                         if not self.client:
                             self.client = BleakClient(self.ble_device)
@@ -312,7 +312,7 @@ class Laifen:
                         if await self.connect():
                             await self.start_notifications()
                             await self.gatherdata()
-                            _LOGGER.info(f"Reconnected to {self.address}")
+                            _LOGGER.debug(f"Reconnected to {self.address}")
                             return True
                 except Exception as e:
                     _LOGGER.debug(f"Reconnect attempt {attempt + 1} failed: {e}")

--- a/custom_components/laifen_ble/laifen/laifen.py
+++ b/custom_components/laifen_ble/laifen/laifen.py
@@ -23,18 +23,18 @@ class Laifen:
         self.lock = asyncio.Lock()  # Ensure concurrency safety
         self._first_message = True  # Ignore initial unwanted message
         self._reconnecting = asyncio.Lock()
-        # _LOGGER.warning(f"Laifen instance created for {self.ble_device.address}")
+        # _LOGGER.debug(f"Laifen instance created for {self.ble_device.address}")
 
     async def scan_for_devices(self):
         """Scan for Laifen toothbrush devices."""
-        # _LOGGER.warning("Scanning for devices...")
+        # _LOGGER.debug("Scanning for devices...")
         scanner = BleakScanner()
         devices = await scanner.discover()
         found_devices = [device for device in devices if device.name and (device.name.startswith("LFTB") or device.name.startswith("Laifen Toothbrush"))]
         if not found_devices:
-            # _LOGGER.warning("No Laifen devices found during scan.")
+            # _LOGGER.debug("No Laifen devices found during scan.")
             return None
-        # _LOGGER.warning(f"Found Laifen devices: {[device.address for device in found_devices]}")
+        # _LOGGER.debug(f"Found Laifen devices: {[device.address for device in found_devices]}")
         return found_devices
 
 
@@ -70,7 +70,7 @@ class Laifen:
                     return True
             except asyncio.CancelledError:
                 if self.coordinator:
-                    _LOGGER.warning(f"Connection to {self.ble_device.address} was cancelled. Marking asleep.")
+                    _LOGGER.debug(f"Connection to {self.ble_device.address} was cancelled. Marking asleep.")
                     self.coordinator.device_asleep = True
                 return False
             except (BleakError, asyncio.TimeoutError, TimeoutError) as e:
@@ -275,17 +275,17 @@ class Laifen:
                 await self.client.disconnect()
                 _LOGGER.debug(f"Disconnected {self.ble_device.address} cleanly")
             except BleakError as e:
-                _LOGGER.warning(f"Error during disconnect: {e}")
+                _LOGGER.debug(f"Error during disconnect: {e}")
             finally:
                 self.client = None  # Ensure cleanup
 
 
     def _handle_disconnect(self, client):
-        _LOGGER.warning(f"{self.ble_device.address} disconnected.")
+        _LOGGER.debug(f"{self.ble_device.address} disconnected.")
         if self.coordinator:
             last_status = self.result.get("status", "Unknown")
 
-            _LOGGER.warning(f"{self.ble_device.address} disconnected — will attempt reconnection.")
+            _LOGGER.debug(f"{self.ble_device.address} disconnected — will attempt reconnection.")
             self.coordinator.device_asleep = False
             asyncio.create_task(self._aggressive_reconnect())
 
@@ -315,7 +315,7 @@ class Laifen:
                             _LOGGER.info(f"Reconnected to {self.address}")
                             return True
                 except Exception as e:
-                    _LOGGER.warning(f"Reconnect attempt {attempt + 1} failed: {e}")
+                    _LOGGER.debug(f"Reconnect attempt {attempt + 1} failed: {e}")
                 attempt += 1
 
             cached = await self.coordinator._async_restore_data()

--- a/custom_components/laifen_ble/sensor.py
+++ b/custom_components/laifen_ble/sensor.py
@@ -57,7 +57,7 @@ class LaifenSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
                     self._last_valid_value = float(last_state.state)
                     # _LOGGER.debug(f"Restored state for {self.entity_id}: {self._last_valid_value}")
                 except ValueError:
-                    _LOGGER.error(f"Could not restore state for {self.entity_id}: {last_state.state}")
+                    _LOGGER.debug(f"Could not restore state for {self.entity_id}: {last_state.state}")
 
     async def _run_timer(self):
         """Increment the timer every second."""

--- a/custom_components/laifen_ble/sensor.py
+++ b/custom_components/laifen_ble/sensor.py
@@ -152,4 +152,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     if entities:
         async_add_entities(entities)
     else:
-        _LOGGER.warning("No valid Laifen sensor entities to add.")
+        _LOGGER.debug("No valid Laifen sensor entities to add.")

--- a/custom_components/laifen_ble/switch.py
+++ b/custom_components/laifen_ble/switch.py
@@ -70,4 +70,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     if entities:
         async_add_entities(entities)
     else:
-        _LOGGER.warning("No valid Laifen switch entities to add.")
+        _LOGGER.debug("No valid Laifen switch entities to add.")


### PR DESCRIPTION
## Changes
- Changed normal operational logs from WARNING to DEBUG
- Updated logging to use % formatting (HA best practice)
- Kept WARNING only for genuine issues

## Motivation
While cleaning up logs for other integrations, noticed this integration 
was generating many WARNING logs for normal behavior (devices sleeping, 
cache restoration, etc). This makes it harder to spot actual problems.

## Result
Cleaner logs by default - only shows warnings when something actually 
needs attention.